### PR TITLE
link to *arr instead of TMDb/TheTVDB if EXTERNAL_URL is set

### DIFF
--- a/arr-discord-notifier.sh
+++ b/arr-discord-notifier.sh
@@ -169,7 +169,9 @@ if [[ ${radarr_eventtype^^} == "DOWNLOAD" ]]; then
         movie_quality_field=""
         if [[ ${drop_fields} != *quality* ]]; then
             movie_quality=$(echo "${movie}" | jq -r '.[].movieFile.quality.quality.name')
-            movie_quality_field='{"name": "Quality", "value": "'${movie_quality}'", "inline": true},'
+            if [[ ${movie_quality} != "null" ]] && [[ -n ${movie_quality} ]]; then
+                movie_quality_field='{"name": "Quality", "value": "'${movie_quality}'", "inline": true},'
+            fi
         fi
 
         # Codecs
@@ -410,7 +412,9 @@ if [[ ${sonarr_eventtype^^} == "DOWNLOAD" ]]; then
             episode_quality_field=""
             if [[ ${drop_fields} != *quality* ]]; then
                 episode_quality=$(echo "${episode_file}" | jq -r '.quality.quality.name')
-                episode_quality_field='{"name": "Quality", "value": "'${episode_quality}'", "inline": true},'
+                if [[ ${episode_quality} != "null" ]] && [[ -n ${episode_quality} ]]; then
+                    episode_quality_field='{"name": "Quality", "value": "'${episode_quality}'", "inline": true},'
+                fi
             fi
 
             # Codecs

--- a/arr-discord-notifier.sh
+++ b/arr-discord-notifier.sh
@@ -122,6 +122,11 @@ if [[ ${radarr_eventtype^^} == "DOWNLOAD" ]]; then
         # Movie Name (Year)
         movie_title=$(echo "${movie}" | jq -r '.[].title')
         movie_release_year=$(echo "${movie}" | jq -r '.[].year')
+        if [[ -z ${EXTERNAL_URL} ]]; then
+            movie_url="https://www.themoviedb.org/movie/${radarr_movie_tmdbid}"
+        else
+            movie_url="${EXTERNAL_URL}/movie/${radarr_movie_tmdbid}"
+        fi
 
         # Overview
         movie_overview_field=""
@@ -241,7 +246,7 @@ if [[ ${radarr_eventtype^^} == "DOWNLOAD" ]]; then
                     {
                         "author": {"name": "'${AUTHOR_NAME}'", "icon_url": "https://raw.githubusercontent.com/docker-hotio/arr-discord-notifier/master/img/radarr/logo.png"},
                         "title": "'${movie_title}' ('${movie_release_year}')",
-                        "url": "https://www.themoviedb.org/movie/'${radarr_movie_tmdbid}'",
+                        "url": "'${movie_url}'",
                         '${movie_poster_field}'
                         '${movie_backdrop_field}'
                         "color": '${COLOR}',
@@ -312,6 +317,12 @@ if [[ ${sonarr_eventtype^^} == "DOWNLOAD" ]]; then
         # TV Show Name (Year)
         tvshow_title=$(echo "${tvshow}" | jq -r '.[].title')
         tvshow_release_year=$(echo "${tvshow}" | jq -r '.[].year')
+        if [[ -z ${EXTERNAL_URL} ]]; then
+            tvshow_url="http://www.thetvdb.com/?tab=series&id=${sonarr_series_tvdbid}"
+        else
+            tvshow_slug="$(curl -fsSL "https://skyhook.sonarr.tv/v1/tvdb/shows/en/${sonarr_series_tvdbid}" | jq -r '.slug')"
+            tvshow_url="${EXTERNAL_URL}/series/${tvshow_slug}"
+        fi
 
         # Rating
         tvshow_rating_field=""
@@ -471,7 +482,7 @@ if [[ ${sonarr_eventtype^^} == "DOWNLOAD" ]]; then
                         {
                             "author": {"name": "'${AUTHOR_NAME}'", "icon_url": "https://raw.githubusercontent.com/docker-hotio/arr-discord-notifier/master/img/sonarr/logo.png"},
                             "title": "'${tvshow_title//([[:digit:]][[:digit:]][[:digit:]][[:digit:]])/}' ('${tvshow_release_year}') - S'$(printf "%02d" "${sonarr_episodefile_seasonnumber}")'E'$(printf "%02d" "${episodes[i]}")'",
-                            "url": "http://www.thetvdb.com/?tab=series&id='${sonarr_series_tvdbid}'",
+                            "url": "'${tvshow_url}'",
                             '${tvshow_poster_field}'
                             '${tvshow_backdrop_field}'
                             "color": '${COLOR}',

--- a/arr-discord-notifier.sh
+++ b/arr-discord-notifier.sh
@@ -122,6 +122,8 @@ if [[ ${radarr_eventtype^^} == "DOWNLOAD" ]]; then
         # Movie Name (Year)
         movie_title=$(echo "${movie}" | jq -r '.[].title')
         movie_release_year=$(echo "${movie}" | jq -r '.[].year')
+
+        # URL
         if [[ -z ${EXTERNAL_URL} ]]; then
             movie_url="https://www.themoviedb.org/movie/${radarr_movie_tmdbid}"
         else
@@ -319,11 +321,13 @@ if [[ ${sonarr_eventtype^^} == "DOWNLOAD" ]]; then
         # TV Show Name (Year)
         tvshow_title=$(echo "${tvshow}" | jq -r '.[].title')
         tvshow_release_year=$(echo "${tvshow}" | jq -r '.[].year')
+
+        # URL
         if [[ -z ${EXTERNAL_URL} ]]; then
             tvshow_url="http://www.thetvdb.com/?tab=series&id=${sonarr_series_tvdbid}"
         else
-            tvshow_slug="$(curl -fsSL "https://skyhook.sonarr.tv/v1/tvdb/shows/en/${sonarr_series_tvdbid}" | jq -r '.slug')"
-            tvshow_url="${EXTERNAL_URL}/series/${tvshow_slug}"
+            tvshow_title_slug=$(echo "${tvshow}" | jq -r '.[].titleSlug')
+            tvshow_url="${EXTERNAL_URL}/series/${tvshow_title_slug}"
         fi
 
         # Rating


### PR DESCRIPTION
Adds the option to link the embed title to Radarr/Sonarr instead of TMDb/TheTVDB, if a user sets the `EXTERNAL_URL` environment variable. 😸

Also, while testing, Sonarr didn't return the quality for an episode, which caused Discord to reject the notification payload due to the empty `""` embed field value, so I added a check for that as well. 👀

@mrhotio I'm not the greatest with shell scripting, so please let me know if anything is weird or needs to be fixed! ❤️